### PR TITLE
Update safe.yaml to version v0.6.14

### DIFF
--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.6.12
+  version: v0.6.14
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -21,45 +21,36 @@ spec:
     For safe commands like get, describe, logs, etc., this plugin acts as a
     transparent pass-through to kubectl without any safety checks.
   platforms:
-  - selector:
       matchLabels:
-        os: linux
-        arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.12/kubectl-safe-linux-amd64.tar.gz
-    sha256: "d2ea297b7b2e18923819d67af37ac82f3c5e7b508c97c43ff774d8a4c2a3d6e5"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-linux-amd64.tar.gz
+    sha256: "5fce6b95661870b12dc38845b83b1071cb4689690960334e798e8d4a546419e8"
     bin: kubectl-safe
-  - selector:
       matchLabels:
-        os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.12/kubectl-safe-linux-arm64.tar.gz
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-linux-arm64.tar.gz
     sha256: ""
     bin: kubectl-safe
-  - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.12/kubectl-safe-darwin-amd64.tar.gz
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-darwin-amd64.tar.gz
     sha256: ""
     bin: kubectl-safe
-  - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.12/kubectl-safe-darwin-arm64.tar.gz
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-darwin-arm64.tar.gz
     sha256: ""
     bin: kubectl-safe
-  - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.12/kubectl-safe-windows-amd64.zip
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-windows-amd64.zip
     sha256: ""
     bin: kubectl-safe.exe
-  - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.12/kubectl-safe-windows-arm64.zip
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-windows-arm64.zip
     sha256: ""
     bin: kubectl-safe.exe

--- a/safe.yaml
+++ b/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.1.0
+  version: v0.6.14
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -21,45 +21,36 @@ spec:
     For safe commands like get, describe, logs, etc., this plugin acts as a
     transparent pass-through to kubectl without any safety checks.
   platforms:
-  - selector:
       matchLabels:
-        os: linux
-        arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.1.0/kubectl-safe-linux-amd64.tar.gz
-    sha256: ""
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-linux-amd64.tar.gz
+    sha256: "5fce6b95661870b12dc38845b83b1071cb4689690960334e798e8d4a546419e8"
     bin: kubectl-safe
-  - selector:
       matchLabels:
-        os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.1.0/kubectl-safe-linux-arm64.tar.gz
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-linux-arm64.tar.gz
     sha256: ""
     bin: kubectl-safe
-  - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.1.0/kubectl-safe-darwin-amd64.tar.gz
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-darwin-amd64.tar.gz
     sha256: ""
     bin: kubectl-safe
-  - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.1.0/kubectl-safe-darwin-arm64.tar.gz
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-darwin-arm64.tar.gz
     sha256: ""
     bin: kubectl-safe
-  - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.1.0/kubectl-safe-windows-amd64.zip
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-windows-amd64.zip
     sha256: ""
     bin: kubectl-safe.exe
-  - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.1.0/kubectl-safe-windows-arm64.zip
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.14/kubectl-safe-windows-arm64.zip
     sha256: ""
     bin: kubectl-safe.exe


### PR DESCRIPTION
Automated update of safe.yaml and plugins/safe.yaml for release v0.6.14
  
  This PR updates:
  - Version number to v0.6.14
  - Download URLs to point to v0.6.14 release
  - SHA256 checksums for all platform binaries
  
  Auto-generated by release workflow.