### PR TITLE
Update safe.yaml to version v0.6.17

### DIFF
--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.6.16
+  version: v0.6.17
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -21,36 +21,45 @@ spec:
     For safe commands like get, describe, logs, etc., this plugin acts as a
     transparent pass-through to kubectl without any safety checks.
   platforms:
+  - selector:
       matchLabels:
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-linux-amd64.tar.gz
-    sha256: "7983858a24e4b4c3a8be3736d66a1b8473ee37b9c05383a9f21c80734f305677"
+        os: linux
+        arch: amd64
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-linux-amd64.tar.gz
+    sha256: "bf2fbf30d0bcdc2e7241f3c97b815ed1892674305e4410070849ccde841a61d8"
     bin: kubectl-safe
+  - selector:
       matchLabels:
+        os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-linux-arm64.tar.gz
-    sha256: ""
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-linux-arm64.tar.gz
+    sha256: "7bbfd9bd9102bd5537b2b30d4e0201bb718fa074de4135374efcb81349b3a768"
     bin: kubectl-safe
+  - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-darwin-amd64.tar.gz
-    sha256: ""
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "5cc4559dd9907583d71f78963397296bae317b30d650352f20ec186d62d7e170"
     bin: kubectl-safe
+  - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-darwin-arm64.tar.gz
-    sha256: ""
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "35af2ee4cfdf819f85a6cbb9ad94ac8d5f523cbdee522600b77addeccad9575b"
     bin: kubectl-safe
+  - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-windows-amd64.zip
-    sha256: ""
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-windows-amd64.zip
+    sha256: "a5ffdbed46ba6da405ee7deba4980559de361b2335aeb4d73f127fd983829802"
     bin: kubectl-safe.exe
+  - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-windows-arm64.zip
-    sha256: ""
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-windows-arm64.zip
+    sha256: "508dceea5a68dba8b3747fb82174ce37234899499299efef5b0f53c6df10493e"
     bin: kubectl-safe.exe

--- a/safe.yaml
+++ b/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.6.16
+  version: v0.6.17
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-linux-amd64.tar.gz
-    sha256: "b2f749590a13ae5f547a9fed58759ba41b8dd1d49e002b8bf048f98c09590dd8"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-linux-amd64.tar.gz
+    sha256: "bf2fbf30d0bcdc2e7241f3c97b815ed1892674305e4410070849ccde841a61d8"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-linux-arm64.tar.gz
-    sha256: "f8ca9aeda67109b54c4bdcb65ad87a0bda4b140ff5b502318fb0e0f6909b9cc3"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-linux-arm64.tar.gz
+    sha256: "7bbfd9bd9102bd5537b2b30d4e0201bb718fa074de4135374efcb81349b3a768"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "ccc17c03fdae0412b8b6a44bdccba6628de776e9fa8f674dd5f83fa0fad30da1"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "5cc4559dd9907583d71f78963397296bae317b30d650352f20ec186d62d7e170"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "30e90c617089287c69e0515bbd547e714077a30a4f258c363a89ab1fe043b56a"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "35af2ee4cfdf819f85a6cbb9ad94ac8d5f523cbdee522600b77addeccad9575b"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-windows-amd64.zip
-    sha256: "bb65faedef9212f823dd7fd3afbd2806b42c8f777859698110ef9e2f593199e8"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-windows-amd64.zip
+    sha256: "a5ffdbed46ba6da405ee7deba4980559de361b2335aeb4d73f127fd983829802"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.16/kubectl-safe-windows-arm64.zip
-    sha256: "b9522dbf8ad49ca47469f87ef5831e643b05b77f995293b1f43639d68b99829e"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.17/kubectl-safe-windows-arm64.zip
+    sha256: "508dceea5a68dba8b3747fb82174ce37234899499299efef5b0f53c6df10493e"
     bin: kubectl-safe.exe


### PR DESCRIPTION
Automated update of safe.yaml and plugins/safe.yaml for release v0.6.17
  
  This PR updates:
  - Version number to v0.6.17
  - Download URLs to point to v0.6.17 release
  - SHA256 checksums for all platform binaries
  
  Auto-generated by release workflow.