### PR TITLE
Update safe.yaml to version v0.6.19

### DIFF
--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.6.18
+  version: v0.6.19
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-linux-amd64.tar.gz
-    sha256: "de2c5150c1319ccd267a34ffe479ce85008a8977708f70c1123c6baa809bb029"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-linux-amd64.tar.gz
+    sha256: "03bb281a29174f4a928bc639518b6f5d9fde450f844f555d930cbe9df9af6b3d"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-linux-arm64.tar.gz
-    sha256: "e1f4436d3f2f116c381b027d188e0180508ec103bd66b2aea87b2b02e4756141"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-linux-arm64.tar.gz
+    sha256: "53968b282067b84bfec47f4576158a3d0018502872ddef1f3bc0815db53ba259"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "2696298c3750f2fa4171de11ef85eb7a8b950b50ac20b982444bc27762a7f696"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "7a75eff10a8fc2da9f1d557a10cd60426f415aa7806c7b17ba1e3230819bf81d"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "6eee0b4208fcae25e877bf414f848b2ab2f6ae401c43a87a0599dcd2f0db946a"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "560b86094c2850b3bcef1c067f028896a49bd1069289f56af197c6a39963d5c3"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-windows-amd64.zip
-    sha256: "1bf73b987108c6eb96a59c60eae04d3e9959528ae556397cc006ca0f6a33141e"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-windows-amd64.zip
+    sha256: "5c5ef518060fef70d94c147bd3b5ba455d799333a5d90687467d767ad440d024"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-windows-arm64.zip
-    sha256: "7cfda961ce9f4acfd5251d77e9ee4397db10aee150a534fa48b0e81167957cf4"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-windows-arm64.zip
+    sha256: "558fecd77f5bc20d8339111c1291ce42f7b52dc854c44b6c706938df77cd5e09"
     bin: kubectl-safe.exe

--- a/safe.yaml
+++ b/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.6.18
+  version: v0.6.19
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-linux-amd64.tar.gz
-    sha256: "de2c5150c1319ccd267a34ffe479ce85008a8977708f70c1123c6baa809bb029"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-linux-amd64.tar.gz
+    sha256: "03bb281a29174f4a928bc639518b6f5d9fde450f844f555d930cbe9df9af6b3d"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-linux-arm64.tar.gz
-    sha256: "e1f4436d3f2f116c381b027d188e0180508ec103bd66b2aea87b2b02e4756141"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-linux-arm64.tar.gz
+    sha256: "53968b282067b84bfec47f4576158a3d0018502872ddef1f3bc0815db53ba259"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "2696298c3750f2fa4171de11ef85eb7a8b950b50ac20b982444bc27762a7f696"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "7a75eff10a8fc2da9f1d557a10cd60426f415aa7806c7b17ba1e3230819bf81d"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "6eee0b4208fcae25e877bf414f848b2ab2f6ae401c43a87a0599dcd2f0db946a"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "560b86094c2850b3bcef1c067f028896a49bd1069289f56af197c6a39963d5c3"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-windows-amd64.zip
-    sha256: "1bf73b987108c6eb96a59c60eae04d3e9959528ae556397cc006ca0f6a33141e"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-windows-amd64.zip
+    sha256: "5c5ef518060fef70d94c147bd3b5ba455d799333a5d90687467d767ad440d024"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.18/kubectl-safe-windows-arm64.zip
-    sha256: "7cfda961ce9f4acfd5251d77e9ee4397db10aee150a534fa48b0e81167957cf4"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.19/kubectl-safe-windows-arm64.zip
+    sha256: "558fecd77f5bc20d8339111c1291ce42f7b52dc854c44b6c706938df77cd5e09"
     bin: kubectl-safe.exe


### PR DESCRIPTION
Automated update of safe.yaml and plugins/safe.yaml for release v0.6.19
  
  This PR updates:
  - Version number to v0.6.19
  - Download URLs to point to v0.6.19 release
  - SHA256 checksums for all platform binaries
  
  Auto-generated by release workflow.