### PR TITLE
Update safe.yaml to version v0.6.21

### DIFF
--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.6.20
+  version: v0.6.21
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-linux-amd64.tar.gz
-    sha256: "2311994d9d6bdf3c1a279a5e1b31ec75cca0d26e248912c7fda91d452cce25ad"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-linux-amd64.tar.gz
+    sha256: "7756ad09c410a2ab58065f608b76bc3a18c0892184f8fb30b70c350fd9f1f090"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-linux-arm64.tar.gz
-    sha256: "621a21bacc37b231d4bdfd6ac72c3117ee2c9d7f35b4e4f33e06521185cfd53d"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-linux-arm64.tar.gz
+    sha256: "2c3a7ff7314a019633e7d2f375f8949b03f48fa1b0fe5afb45a024041fb2c65c"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "abda521e4963d6357cd7d64ac62d65de7d1db87af74b1ee571ff8456f79eddad"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "642f8c2288407d7018c8382b03ff7f19f6a8c47525f2a32f8f7885b8f30a2169"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "4ea96ba1a0c203d99eef4c560c04b4e56e0a1c1b56c7a4a66cffab73947e9d4a"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "01857756c885409232f64d54f6830075b06cfcd14859698e4a694a18a15685f7"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-windows-amd64.zip
-    sha256: "752baca31e38e80c3f6e2868e2a2ac06f200cda8a0b94bb75cdfb44027a38146"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-windows-amd64.zip
+    sha256: "713cfddc311a884b73e749ae4894961a26df55e5e3ad1658862750c0641fdf39"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-windows-arm64.zip
-    sha256: "769bd5b366caf8b9169a6ad6f79025f9a683216677d11f19720241dceddc83d8"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-windows-arm64.zip
+    sha256: "75bac7824dfe492d111dca2fc48f99be04f0c348663618de07c8c83bc1ec1e51"
     bin: kubectl-safe.exe

--- a/safe.yaml
+++ b/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.6.20
+  version: v0.6.21
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-linux-amd64.tar.gz
-    sha256: "2311994d9d6bdf3c1a279a5e1b31ec75cca0d26e248912c7fda91d452cce25ad"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-linux-amd64.tar.gz
+    sha256: "7756ad09c410a2ab58065f608b76bc3a18c0892184f8fb30b70c350fd9f1f090"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-linux-arm64.tar.gz
-    sha256: "621a21bacc37b231d4bdfd6ac72c3117ee2c9d7f35b4e4f33e06521185cfd53d"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-linux-arm64.tar.gz
+    sha256: "2c3a7ff7314a019633e7d2f375f8949b03f48fa1b0fe5afb45a024041fb2c65c"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "abda521e4963d6357cd7d64ac62d65de7d1db87af74b1ee571ff8456f79eddad"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "642f8c2288407d7018c8382b03ff7f19f6a8c47525f2a32f8f7885b8f30a2169"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "4ea96ba1a0c203d99eef4c560c04b4e56e0a1c1b56c7a4a66cffab73947e9d4a"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "01857756c885409232f64d54f6830075b06cfcd14859698e4a694a18a15685f7"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-windows-amd64.zip
-    sha256: "752baca31e38e80c3f6e2868e2a2ac06f200cda8a0b94bb75cdfb44027a38146"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-windows-amd64.zip
+    sha256: "713cfddc311a884b73e749ae4894961a26df55e5e3ad1658862750c0641fdf39"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.20/kubectl-safe-windows-arm64.zip
-    sha256: "769bd5b366caf8b9169a6ad6f79025f9a683216677d11f19720241dceddc83d8"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.6.21/kubectl-safe-windows-arm64.zip
+    sha256: "75bac7824dfe492d111dca2fc48f99be04f0c348663618de07c8c83bc1ec1e51"
     bin: kubectl-safe.exe


### PR DESCRIPTION
Automated update of safe.yaml and plugins/safe.yaml for release v0.6.21
  
  This PR updates:
  - Version number to v0.6.21
  - Download URLs to point to v0.6.21 release
  - SHA256 checksums for all platform binaries
  
  Auto-generated by release workflow.