### PR TITLE
Update safe.yaml to version v1.0.0

### DIFF
--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.8.0-colorized
+  version: v1.0.0
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-linux-amd64.tar.gz
-    sha256: "f5ad2a3b52f93f9df4b4578f5a34a046f2dbc4615f02ca2fdcb35b380953c646"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-linux-amd64.tar.gz
+    sha256: "b00cbd121daba19d62733cb534a05e922facd1e2db6bcc28f01dd409ef0ed252"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-linux-arm64.tar.gz
-    sha256: "f1e14e12718cf5726e94fa1b5709ce7ef0095e7123e71bfe47a1032b6d9c2d54"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-linux-arm64.tar.gz
+    sha256: "4f3952ff038ed722e5de6e5c33fb0327bbe4567718e37afb5f1d70df4b0ba998"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "302aa9b4fa2dd526863e5ae8a48667a3e0179bd5fc46926fcdfb7d3ee4440640"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "1a7d77218bffa1ba6b4b22e63e6385ad8d1a5fdc418efad5d50cc334e033bf6a"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "f5541d36c61ed699eb2be9bde7eb9d1cec756480b7fa7f60d7088939a3f964dc"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "a65eda9665a472f5dcc698fa7faf388e677a1b137b49e7f15ab9899b1c1a193b"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-windows-amd64.zip
-    sha256: "542ed937475fb6945d95d869c6d2d49f27d0711e86bea56da7ffc0fe3c6b388f"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-windows-amd64.zip
+    sha256: "d385cf45eceffb6ad2517d5a96627d3a5f74deb65a352a856106a41990e1fdbd"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-windows-arm64.zip
-    sha256: "0b3d865fbc00f1e6fc75328d6cf87f7f7ecb5ae9bcbbfb70f71be1c00dda912e"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-windows-arm64.zip
+    sha256: "5e2bf9cb7dfb4d5fac7faf3df5df118b0d59472fff912ac7f1e396da7cd90ab0"
     bin: kubectl-safe.exe

--- a/safe.yaml
+++ b/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v0.8.0-colorized
+  version: v1.0.0
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-linux-amd64.tar.gz
-    sha256: "f5ad2a3b52f93f9df4b4578f5a34a046f2dbc4615f02ca2fdcb35b380953c646"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-linux-amd64.tar.gz
+    sha256: "b00cbd121daba19d62733cb534a05e922facd1e2db6bcc28f01dd409ef0ed252"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-linux-arm64.tar.gz
-    sha256: "f1e14e12718cf5726e94fa1b5709ce7ef0095e7123e71bfe47a1032b6d9c2d54"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-linux-arm64.tar.gz
+    sha256: "4f3952ff038ed722e5de6e5c33fb0327bbe4567718e37afb5f1d70df4b0ba998"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "302aa9b4fa2dd526863e5ae8a48667a3e0179bd5fc46926fcdfb7d3ee4440640"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "1a7d77218bffa1ba6b4b22e63e6385ad8d1a5fdc418efad5d50cc334e033bf6a"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "f5541d36c61ed699eb2be9bde7eb9d1cec756480b7fa7f60d7088939a3f964dc"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "a65eda9665a472f5dcc698fa7faf388e677a1b137b49e7f15ab9899b1c1a193b"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-windows-amd64.zip
-    sha256: "542ed937475fb6945d95d869c6d2d49f27d0711e86bea56da7ffc0fe3c6b388f"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-windows-amd64.zip
+    sha256: "d385cf45eceffb6ad2517d5a96627d3a5f74deb65a352a856106a41990e1fdbd"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v0.8.0-colorized/kubectl-safe-windows-arm64.zip
-    sha256: "0b3d865fbc00f1e6fc75328d6cf87f7f7ecb5ae9bcbbfb70f71be1c00dda912e"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.0/kubectl-safe-windows-arm64.zip
+    sha256: "5e2bf9cb7dfb4d5fac7faf3df5df118b0d59472fff912ac7f1e396da7cd90ab0"
     bin: kubectl-safe.exe


### PR DESCRIPTION
Automated update of safe.yaml and plugins/safe.yaml for release v1.0.0
  
  This PR updates:
  - Version number to v1.0.0
  - Download URLs to point to v1.0.0 release
  - SHA256 checksums for all platform binaries
  
  Auto-generated by release workflow.