### PR TITLE
Update safe.yaml to version v1.0.4

### DIFF
--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v1.0.3
+  version: v1.0.4
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-linux-amd64.tar.gz
-    sha256: "e0919b5090ef7423fe29ae48980c601c7eb5973a5660fd48bca2a13a281fac43"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-linux-amd64.tar.gz
+    sha256: "bc85447db39dc0673e681238c0c97463f4f32aab712745053034813917c3c7fc"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-linux-arm64.tar.gz
-    sha256: "9d21c857a20e9eed5c75e07d1dda3563b277d2a0d8db27dc8ab0c8b28e56a57e"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-linux-arm64.tar.gz
+    sha256: "2c2002be17cac3cb89e111e4d205442906136cb5230d8390b7fbc9fa0967377c"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "cf3770ccc55d83ca3ea22bab29d698e6261c563a27df96408e9cb152376ca2d2"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "1ceb8b42a06e4a797892d4c7015d043a3fce1fbe4da82b7950445cdeb7fb3012"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "b4121a6942305531ac649ccdc8b860523ecb3ae0145a1a36a5ed72e30e41bfce"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "18314ad00683574342eb65d214cc37681beb852d633333ae6bc7169deda3b5cb"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-windows-amd64.zip
-    sha256: "f7b882324feb16ec803d5450a813b967f721ca15980a8a57ce3fa0f547cb6b13"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-windows-amd64.zip
+    sha256: "56f8c71d09a2a2688595c89e4408f0e68f96a560e794cfc812e1569f461f8258"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-windows-arm64.zip
-    sha256: "ea75955afadcf91a92b65c1807b9f43296317c5589137bc32a436530afa9f540"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-windows-arm64.zip
+    sha256: "f1d964608ab82817f74446c2f24f95221d4b1b2d2e1dfc1df49f0234672f5f3e"
     bin: kubectl-safe.exe

--- a/safe.yaml
+++ b/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v1.0.3
+  version: v1.0.4
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for dangerous kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-linux-amd64.tar.gz
-    sha256: "e0919b5090ef7423fe29ae48980c601c7eb5973a5660fd48bca2a13a281fac43"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-linux-amd64.tar.gz
+    sha256: "bc85447db39dc0673e681238c0c97463f4f32aab712745053034813917c3c7fc"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-linux-arm64.tar.gz
-    sha256: "9d21c857a20e9eed5c75e07d1dda3563b277d2a0d8db27dc8ab0c8b28e56a57e"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-linux-arm64.tar.gz
+    sha256: "2c2002be17cac3cb89e111e4d205442906136cb5230d8390b7fbc9fa0967377c"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "cf3770ccc55d83ca3ea22bab29d698e6261c563a27df96408e9cb152376ca2d2"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "1ceb8b42a06e4a797892d4c7015d043a3fce1fbe4da82b7950445cdeb7fb3012"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "b4121a6942305531ac649ccdc8b860523ecb3ae0145a1a36a5ed72e30e41bfce"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "18314ad00683574342eb65d214cc37681beb852d633333ae6bc7169deda3b5cb"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-windows-amd64.zip
-    sha256: "f7b882324feb16ec803d5450a813b967f721ca15980a8a57ce3fa0f547cb6b13"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-windows-amd64.zip
+    sha256: "56f8c71d09a2a2688595c89e4408f0e68f96a560e794cfc812e1569f461f8258"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.3/kubectl-safe-windows-arm64.zip
-    sha256: "ea75955afadcf91a92b65c1807b9f43296317c5589137bc32a436530afa9f540"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.4/kubectl-safe-windows-arm64.zip
+    sha256: "f1d964608ab82817f74446c2f24f95221d4b1b2d2e1dfc1df49f0234672f5f3e"
     bin: kubectl-safe.exe


### PR DESCRIPTION
Automated update of safe.yaml and plugins/safe.yaml for release v1.0.4
  
  This PR updates:
  - Version number to v1.0.4
  - Download URLs to point to v1.0.4 release
  - SHA256 checksums for all platform binaries
  
  Auto-generated by release workflow.