### PR TITLE
Update safe.yaml to version v1.0.6

### DIFF
--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v1.0.5
+  version: v1.0.6
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for modifying kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-linux-amd64.tar.gz
-    sha256: "d64a7f94a6a37441eabbae1d333fbb64ee0d6e50c6fc3aeab8c55220664c7df7"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-linux-amd64.tar.gz
+    sha256: "7ae564bf25de9f66411a3fa88d3fd15e5ce4507fd0ca3466da64221d6289a90b"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-linux-arm64.tar.gz
-    sha256: "96962af57616a68a779b3e60372aded0118ea6c9aca04fe9b8a9b37bffa76a52"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-linux-arm64.tar.gz
+    sha256: "b38ad917802b7744ead57e50cd739a918b8fdcc61475d59613744aff4c125c86"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "219d524bcd07c1eca8509c5a0f35e28f841808096a8692057c4d7d046cef2496"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "62b6fbd03a2ef0793bc7196550eb6fabf357b8a9e07fe69d134132a07a6c3c40"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "963efa28ed374985721545c6a429c628a26b8e919761eda924dd80a005a8c45a"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "e9cc0fd386dbba89bd617655f61f1b5a96b03b1179d0ab315d5366d436a04754"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-windows-amd64.zip
-    sha256: "1a2172afaf38df9894cfc0380e0e35f8a98a63ba71d46b89e1253e0d2d83bccb"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-windows-amd64.zip
+    sha256: "559332b32be5ac930caaa4823fb0dc48278fb0adb0c7a57bcb438ef97ec947c6"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-windows-arm64.zip
-    sha256: "dc4f43bc6aac876f94d2d6d049dcc942f6371e607123dbd7f67f61d38b827a94"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-windows-arm64.zip
+    sha256: "f75b1a2d8cdccc4901ae3ed5daaa92ebec8c8a4a3f100f38f5d8973f6b8a8ea5"
     bin: kubectl-safe.exe

--- a/safe.yaml
+++ b/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: v1.0.5
+  version: v1.0.6
   homepage: https://github.com/bjrooney/kubectl-safe
   shortDescription: Interactive safety net for modifying kubectl commands
   description: |
@@ -25,41 +25,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-linux-amd64.tar.gz
-    sha256: "d64a7f94a6a37441eabbae1d333fbb64ee0d6e50c6fc3aeab8c55220664c7df7"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-linux-amd64.tar.gz
+    sha256: "7ae564bf25de9f66411a3fa88d3fd15e5ce4507fd0ca3466da64221d6289a90b"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-linux-arm64.tar.gz
-    sha256: "96962af57616a68a779b3e60372aded0118ea6c9aca04fe9b8a9b37bffa76a52"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-linux-arm64.tar.gz
+    sha256: "b38ad917802b7744ead57e50cd739a918b8fdcc61475d59613744aff4c125c86"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-darwin-amd64.tar.gz
-    sha256: "219d524bcd07c1eca8509c5a0f35e28f841808096a8692057c4d7d046cef2496"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-darwin-amd64.tar.gz
+    sha256: "62b6fbd03a2ef0793bc7196550eb6fabf357b8a9e07fe69d134132a07a6c3c40"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-darwin-arm64.tar.gz
-    sha256: "963efa28ed374985721545c6a429c628a26b8e919761eda924dd80a005a8c45a"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-darwin-arm64.tar.gz
+    sha256: "e9cc0fd386dbba89bd617655f61f1b5a96b03b1179d0ab315d5366d436a04754"
     bin: kubectl-safe
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-windows-amd64.zip
-    sha256: "1a2172afaf38df9894cfc0380e0e35f8a98a63ba71d46b89e1253e0d2d83bccb"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-windows-amd64.zip
+    sha256: "559332b32be5ac930caaa4823fb0dc48278fb0adb0c7a57bcb438ef97ec947c6"
     bin: kubectl-safe.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.5/kubectl-safe-windows-arm64.zip
-    sha256: "dc4f43bc6aac876f94d2d6d049dcc942f6371e607123dbd7f67f61d38b827a94"
+    uri: https://github.com/bjrooney/kubectl-safe/releases/download/v1.0.6/kubectl-safe-windows-arm64.zip
+    sha256: "f75b1a2d8cdccc4901ae3ed5daaa92ebec8c8a4a3f100f38f5d8973f6b8a8ea5"
     bin: kubectl-safe.exe


### PR DESCRIPTION
Automated update of safe.yaml and plugins/safe.yaml for release v1.0.6
  
  This PR updates:
  - Version number to v1.0.6
  - Download URLs to point to v1.0.6 release
  - SHA256 checksums for all platform binaries
  
  Auto-generated by release workflow.