### PR TITLE
chore: gitignore .vscode/, drop main.go.legacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,8 @@ go.work.sum
 .env
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode/
 # Ignore the distribution directory where binaries are built.
 dist/
 


### PR DESCRIPTION
Two stale items lingering in working tree.

- `.vscode/settings.json` — editor config; gitignore had `.vscode/` commented out. Uncommented.
- `main.go.legacy` — 232-line pre-refactor monolith. Current entry point is `cmd/kubectl-safe/main.go`. Removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)